### PR TITLE
Initial development of Amdahl's Law plotting

### DIFF
--- a/code/Snakefile
+++ b/code/Snakefile
@@ -1,0 +1,27 @@
+# Snakefile to run Amdahl's Law for HPC Workflows
+
+TASKS = [1, 2, 4, 8, 16, 32]
+
+def get_tasks(wildcards):
+        return int(wildcards.sample)
+
+rule plot:
+    input:
+        expand("run_{task}.log", task=TASKS)
+    output:
+        "done.log"
+    shell:
+        "python3 plot_amdahl.py > done.log"
+
+rule slurm:
+    input:
+    output:
+        "run_{sample}.log"
+    resources:
+        tasks=get_tasks
+    shell:
+        "mpirun -np {wildcards.sample} amdahl --terse > run_{wildcards.sample}.log"
+
+rule clean:
+    shell:
+        "rm *.log"

--- a/code/Snakefile
+++ b/code/Snakefile
@@ -1,6 +1,9 @@
 # Snakefile to run Amdahl's Law for HPC Workflows
 
-TASKS = range(1, 32)  # number of processors: start small for testing!
+cpu_min = 1
+cpu_max = 32
+
+TASKS = range(cpu_min, cpu_max + 1)  # number of processors: start small for testing!
 
 rule plot:
     input:
@@ -14,7 +17,7 @@ rule plot:
     conda:
         "amdahl"
     shell:
-        "python3 plot_amdahl.py > {output}"
+        "python3 plot_amdahl.py {input} > {output}"
 
 rule amdahl:
     input:

--- a/code/Snakefile
+++ b/code/Snakefile
@@ -7,35 +7,36 @@ TASKS = range(cpu_min, cpu_max + 1)  # number of processors: start small for tes
 
 rule plot:
     input:
-        expand("amdahl_np{task}.json", task=TASKS)
+        expand("amdahl_np_{task}.json", task=TASKS)
     output:
-        "plot.log"
-    log:
-        "slurm_plot.out"
+        "amdahl-scaling-study.png"
     resources:
         tasks=1
     conda:
         "amdahl"
     shell:
-        "python3 plot_amdahl.py {input} > {output}"
+        "python3 plot_amdahl.py {input} {output}"
 
 rule amdahl:
     input:
     output:
-        "amdahl_np{sample}.json"
-    log:
-        "slurm_np{sample}.out"
+        "amdahl_np_{sample}.json"
     resources:
         tasks=lambda wildcards: int(wildcards.sample)
+    conda:
+        "amdahl"
     shell:
         "mpirun amdahl --terse > {output}"
 
 rule clean:
     input:
     output:
-    resources:
-        tasks=1
+    params:
+        results=expand("amdahl_np_{task}.json", task=TASKS),
+        stdouts=expand("logs/slurm_amdahl_np_{task}.log", task=TASKS),
+        plotimg="amdahl-scaling-study.png",
+        plotlog="logs/slurm_plot_np_1.log"
     conda:
         "amdahl"
     shell:
-        "rm *.json *.log *.out *.png"
+        "rm -vf {params.results} {params.stdouts} {params.plotimg} {params.plotlog}"

--- a/code/Snakefile
+++ b/code/Snakefile
@@ -11,7 +11,7 @@ rule plot:
     output:
         "plot.log"
     log:
-        "slurm_plot.log"
+        "slurm_plot.out"
     resources:
         tasks=1
     conda:
@@ -38,4 +38,4 @@ rule clean:
     conda:
         "amdahl"
     shell:
-        "rm *.log *.json *.png"
+        "rm *.json *.log *.out *.png"

--- a/code/Snakefile
+++ b/code/Snakefile
@@ -25,7 +25,7 @@ rule amdahl:
     resources:
         tasks=lambda wildcards: int(wildcards.sample)
     shell:
-        "mpirun amdahl --terse --exact > {output}"
+        "mpirun amdahl --terse > {output}"
 
 rule clean:
     input:

--- a/code/Snakefile
+++ b/code/Snakefile
@@ -7,7 +7,8 @@ TASKS = range(cpu_min, cpu_max + 1)  # number of processors: start small for tes
 
 rule plot:
     input:
-        expand("amdahl_np_{task}.json", task=TASKS)
+        script="plot_amdahl.py",
+        data=expand("amdahl_np_{task}.json", task=TASKS)
     output:
         "amdahl-scaling-study.png"
     resources:
@@ -15,7 +16,7 @@ rule plot:
     conda:
         "amdahl"
     shell:
-        "python3 plot_amdahl.py {input} {output}"
+        "python3 {input.script} {input.data} {output}"
 
 rule amdahl:
     input:

--- a/code/Snakefile
+++ b/code/Snakefile
@@ -1,27 +1,38 @@
 # Snakefile to run Amdahl's Law for HPC Workflows
 
-TASKS = [1, 2, 4, 8, 16, 32]
-
-def get_tasks(wildcards):
-        return int(wildcards.sample)
+TASKS = range(1, 32)  # number of processors: start small for testing!
 
 rule plot:
     input:
-        expand("run_{task}.log", task=TASKS)
+        expand("amdahl_np{task}.json", task=TASKS)
     output:
-        "done.log"
+        "plot.log"
+    log:
+        "slurm_plot.log"
+    resources:
+        tasks=1
+    conda:
+        "amdahl"
     shell:
-        "python3 plot_amdahl.py > done.log"
+        "python3 plot_amdahl.py > {output}"
 
-rule slurm:
+rule amdahl:
     input:
     output:
-        "run_{sample}.log"
+        "amdahl_np{sample}.json"
+    log:
+        "slurm_np{sample}.out"
     resources:
-        tasks=get_tasks
+        tasks=lambda wildcards: int(wildcards.sample)
     shell:
-        "mpirun -np {wildcards.sample} amdahl --terse > run_{wildcards.sample}.log"
+        "mpirun amdahl --terse --exact > {output}"
 
 rule clean:
+    input:
+    output:
+    resources:
+        tasks=1
+    conda:
+        "amdahl"
     shell:
-        "rm *.log"
+        "rm *.log *.json *.png"

--- a/code/cluster/config.yaml
+++ b/code/cluster/config.yaml
@@ -35,7 +35,7 @@ default-resources:
 # ------------------------------------------
 
 # root of Conda or Mamba installation on the machine
-conda-base-path: "/toolbox/tnk10/opt/mambaforge"
+conda-base-path: "~/anaconda"
 
 # use a Conda environment
 use-conda: true

--- a/code/cluster/config.yaml
+++ b/code/cluster/config.yaml
@@ -16,19 +16,23 @@
 # <https://github.com/snakemake/snakemake/blob/main/snakemake/__init__.py>
 
 cluster:
+  mkdir -p logs/{rule} &&
   sbatch
     --job-name={rule}-np{resources.tasks}
     --partition={resources.partition}
     --nodes={resources.nodes}
     --ntasks={resources.tasks}
     --time={resources.time}
-    --output={log}
+    --output=logs/slurm_{rule}_np_{resources.tasks}.log
+    --parsable  # required to pass job IDs to scancel
 
 default-resources:
   - partition=rack6  # name of partition (or queue) on which jobs will run
   - nodes=1  # number of cluster nodes to reserve
   - tasks=1  # number of cluster cores to reserve (total)
   - time=5   # maximum expected runtime of each job, in minutes
+
+cluster-cancel: scancel
 
 # ------------------------------------------
 # Global job settings (platform independent)

--- a/code/cluster/config.yaml
+++ b/code/cluster/config.yaml
@@ -35,7 +35,7 @@ default-resources:
 # ------------------------------------------
 
 # root of Conda or Mamba installation on the machine
-conda-base-path: "~/anaconda"
+conda-base-path: "${CONDA_PREFIX}"
 
 # use a Conda environment
 use-conda: true

--- a/code/cluster/config.yaml
+++ b/code/cluster/config.yaml
@@ -16,7 +16,7 @@
 # <https://github.com/snakemake/snakemake/blob/main/snakemake/__init__.py>
 
 cluster:
-  mkdir -p logs/{rule} &&
+  mkdir -p logs &&
   sbatch
     --job-name={rule}-np{resources.tasks}
     --partition={resources.partition}

--- a/code/cluster/config.yaml
+++ b/code/cluster/config.yaml
@@ -1,0 +1,67 @@
+# Cluster profile for Snakemake used in the HPC Workflows lessons
+#
+# This is a YAML file (<https://yaml.org>, a hierarchical plain-text
+# data storage format for lists, key-value pairs, and nested instances
+# of either or both. Indentation and punctuation matter!
+#
+# Use a YAML linter to check for syntax errors after editing:
+#    yamllint config.yaml
+---
+# --------------------------------------
+# Scheduler settings (cluster-dependent)
+# --------------------------------------
+
+# A full listing is in the Snakemake distribution's top-level `__init__.py`
+# file. You can view the latest version on the official repository:
+# <https://github.com/snakemake/snakemake/blob/main/snakemake/__init__.py>
+
+cluster:
+  sbatch
+    --job-name={rule}-np{resources.tasks}
+    --partition={resources.partition}
+    --nodes={resources.nodes}
+    --ntasks={resources.tasks}
+    --time={resources.time}
+    --output={log}
+
+default-resources:
+  - partition=rack6  # name of partition (or queue) on which jobs will run
+  - nodes=1  # number of cluster nodes to reserve
+  - tasks=1  # number of cluster cores to reserve (total)
+  - time=5   # maximum expected runtime of each job, in minutes
+
+# ------------------------------------------
+# Global job settings (platform independent)
+# ------------------------------------------
+
+# root of Conda or Mamba installation on the machine
+conda-base-path: "/toolbox/tnk10/opt/mambaforge"
+
+# use a Conda environment
+use-conda: true
+
+# run at most N CPU cluster jobs in parallel
+# default: number of cores on host machine
+jobs: 500
+
+# max frequency of job status checks
+# default: 10
+max-status-checks-per-second: 1
+
+# use at most N cores of the host machine in parallel
+# (the cores are used to execute local rules)
+# default: number of cores on host machine
+local-cores: 1
+
+# how many seconds to wait for an output file
+# to appear after the execution of a rule
+# default: 3
+latency-wait: 60
+
+# keep going with independent jobs if a job fails?
+# default: false
+keep-going: false
+
+# print the shell command of each job
+# default: false
+printshellcmds: true

--- a/code/plot_amdahl.py
+++ b/code/plot_amdahl.py
@@ -7,54 +7,70 @@ import json
 import matplotlib
 import matplotlib.pyplot as plt
 import sys
+from math import ceil
 matplotlib.use("AGG")  # plot to disk, rather than to a window
 
-
-def amdahl_speedup(parallel_wall_time, serial_wall_time):
+def actual_speedup(parallel_wall_time, serial_wall_time):
     return serial_wall_time / parallel_wall_time
 
 
+def amdahl_speedup(serial_proportion, parallel_proportion, num_cores):
+    normalized_run_time = serial_proportion + (parallel_proportion / num_cores)
+    return 1.0 / normalized_run_time
+
 def analyze_scaling_study(log_files, img_file):
     # Initialize empty variable to hold data(frame)
-    df = None
+    data_frame = None
 
     # Append log files to the dataframe
     for log_file in log_files:
-        with open(log_file, 'r') as f:
+        with open(log_file, "r") as f:
             data = json.loads(f.read())
-            df = pd.concat([df, pd.DataFrame([data])])
+            data_frame = pd.concat([data_frame, pd.DataFrame([data])])
 
     # Sort by processor count, print for reference
-    df.sort_values(by='nproc', inplace=True)
+    data_frame.sort_values(by="nproc", inplace=True)
 
     # Calculate speedup factor
-    serial_wall_time = df.iloc[0]['execution_time']
-    df["speedup"] = df["execution_time"].apply(amdahl_speedup,
-                                               args=(serial_wall_time,))
+    serial_wall_time = data_frame.iloc[0]["execution_time"]
+    data_frame["speedup"] = data_frame["execution_time"].apply(actual_speedup,
+                                                               args=(serial_wall_time,))
 
     # Print out the data frame as a table
-    print(df.to_string(index=False))
+    print(data_frame.to_string(index=False))
 
-    plt.plot(df['nproc'], df["speedup"], 'o', label='Actual')
-
-    # Calculate and plot theoretical speedup factor
-    parallel_proportion = df.iloc[0]['parallel_proportion']
-    serial_proportion = 1 - parallel_proportion
-    processors_range = range(1, df['nproc'].max())
-    speedup = 1.0 / (serial_proportion + (parallel_proportion/processors_range))
-    plt.plot(processors_range, speedup, ':', label='Theoretical')
+    # Create the plot object
+    plt.figure()
 
     # Make graph more legible
-    plt.xlabel('Number of Processes')
-    plt.ylabel('Speedup Factor')
-
-    parallel_percent = int(100 * df.iloc[0]['parallel_proportion'])
-
-    title = "Amdahl's Law Example, {}% parallel".format(parallel_percent)
+    parallel_percent = 100 * data_frame["parallel_proportion"].iloc[0]
+    title = "Amdahl's Law: {:.0f}% Parallel Work".format(parallel_percent)
     plt.title(title)
-    plt.legend(loc="best")
+    plt.xlabel("Number of Processes $N$")
+    plt.ylabel("Speedup Factor $S$")
 
-    plt.savefig(img_file, dpi=400, bbox_inches='tight')
+    # Print the scaling study data
+    plt.plot(data_frame["nproc"], data_frame["speedup"], "o", label="actual data")
+
+    # Save the limits of the plotted data in x and y
+    data_range = [plt.xlim(), plt.ylim()]
+
+    # Calculate and plot theoretical speedup factor
+    markers = matplotlib.lines.Line2D.filled_markers
+    for index, parallel_proportion in enumerate((0.7, 0.8, 0.9, 1)):
+        serial_proportion = 1 - parallel_proportion
+        num_cores = range(1, data_frame["nproc"].max() + 1)
+        speedup = [amdahl_speedup(serial_proportion, parallel_proportion, x) for x in num_cores]
+        label = r"theory, $p=%.2f$" % parallel_proportion
+        plt.plot(num_cores, speedup, linestyle=":", marker=markers[index+1], markersize=4, label=label, zorder=0)
+
+    # Reset plot limits to the actual data
+    plt.xlim(data_range[0])
+    plt.ylim(data_range[1])
+
+    # Show the legend and store the plot as an image
+    plt.legend(loc="best")
+    plt.savefig(img_file, dpi=400, bbox_inches="tight")
 
 
 if __name__ == "__main__":

--- a/code/plot_amdahl.py
+++ b/code/plot_amdahl.py
@@ -2,13 +2,14 @@
 Plotting script for HPC Workflows scaling study
 """
 
-import pandas as pd
 import json
-import matplotlib
 import matplotlib.pyplot as plt
+import pandas as pd
 import sys
+
 from math import ceil
-matplotlib.use("AGG")  # plot to disk, rather than to a window
+from matplotlib.lines import Line2D
+
 
 def actual_speedup(parallel_wall_time, serial_wall_time):
     return serial_wall_time / parallel_wall_time
@@ -33,8 +34,10 @@ def analyze_scaling_study(log_files, img_file):
 
     # Calculate speedup factor
     serial_wall_time = data_frame.iloc[0]["execution_time"]
-    data_frame["speedup"] = data_frame["execution_time"].apply(actual_speedup,
-                                                               args=(serial_wall_time,))
+    data_frame["speedup"] = data_frame["execution_time"].apply(
+        actual_speedup,
+        args=(serial_wall_time,)
+    )
 
     # Print out the data frame as a table
     print(data_frame.to_string(index=False))
@@ -50,19 +53,22 @@ def analyze_scaling_study(log_files, img_file):
     plt.ylabel("Speedup Factor $S$")
 
     # Print the scaling study data
-    plt.plot(data_frame["nproc"], data_frame["speedup"], "o", label="actual data")
+    plt.plot(data_frame["nproc"], data_frame["speedup"],
+             "o", label="actual data")
 
     # Save the limits of the plotted data in x and y
     data_range = [plt.xlim(), plt.ylim()]
 
     # Calculate and plot theoretical speedup factor
-    markers = matplotlib.lines.Line2D.filled_markers
+    markers = Line2D.filled_markers
     for index, parallel_proportion in enumerate((0.7, 0.8, 0.9, 1)):
         serial_proportion = 1 - parallel_proportion
         num_cores = range(1, data_frame["nproc"].max() + 1)
-        speedup = [amdahl_speedup(serial_proportion, parallel_proportion, x) for x in num_cores]
+        speedup = [amdahl_speedup(serial_proportion, parallel_proportion, x)
+                   for x in num_cores]
         label = r"theory, $p=%.2f$" % parallel_proportion
-        plt.plot(num_cores, speedup, linestyle=":", marker=markers[index+1], markersize=4, label=label, zorder=0)
+        plt.plot(num_cores, speedup, linestyle=":", marker=markers[index+1],
+                 markersize=4, label=label, zorder=0)
 
     # Reset plot limits to the actual data
     plt.xlim(data_range[0])

--- a/code/plot_amdahl.py
+++ b/code/plot_amdahl.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Aug 10 07:15:29 2022
+
+@author: renfro
+"""
+
+import pandas as pd
+import glob
+import json # until we get pd.read_json working
+import matplotlib
+matplotlib.use("AGG")
+import matplotlib.pyplot as plt
+
+# Get list of log files, read first one into dataframe
+log_files = glob.glob('run*.log')
+with open(log_files[0], 'r') as f:
+    df = pd.DataFrame([json.loads(f.read())])
+
+# Append rest of log files into same dataframe
+for log_file in log_files[1:]:
+        with open(log_file, 'r') as f:
+            df = pd.concat([df, pd.DataFrame([json.loads(f.read())])])
+
+# Sort by processor count, print for reference
+df.sort_values(by = 'nproc', inplace=True)
+print(df)
+
+# Calculate and plot speedup factor
+serial_time = df.iloc[0]['execution_time']
+plt.plot(df['nproc'], serial_time/df['execution_time'], 'o', label='Actual')
+# Calculate and plot theoretical speedup factor
+parallel_proportion = df.iloc[0]['parallel_proportion']
+processors_range = range(1, df['nproc'].max())
+speedup = 1.0/((1-parallel_proportion)+parallel_proportion/processors_range)
+plt.plot(processors_range, speedup, ':', label='Theoretical')
+
+# Make graph more legible
+plt.xlabel('Number of Processes')
+plt.ylabel('Speedup Factor')
+plt.legend()
+parallel_percent = df.iloc[0]['parallel_proportion']*100
+title = "Amdahl's Law Example, {0}% parallel".format(parallel_percent)
+plt.title(title)
+filename = 'amdahl-{0:03.0f}-percent.png'.format(parallel_percent)
+plt.savefig(filename, bbox_inches='tight')

--- a/code/plot_amdahl.py
+++ b/code/plot_amdahl.py
@@ -9,47 +9,66 @@ import matplotlib.pyplot as plt
 import sys
 matplotlib.use("AGG")  # plot to disk, rather than to a window
 
-usage = "plot_amdahl.py list_of_inputs.json"
 
-# Check whether filenames were supplied
-if len(sys.argv) == 0:
-    print(usage)
-    sys.exit(1)
+def amdahl_speedup(parallel_wall_time, serial_wall_time):
+    return serial_wall_time / parallel_wall_time
 
-# Get list of log files
-log_files = sys.argv[1:]
 
-df = None  # Initialize an empty DataFrame
+def analyze_scaling_study(log_files, img_file):
+    # Initialize empty variable to hold data(frame)
+    df = None
 
-# Append log files to the dataframe
-for log_file in log_files:
-    with open(log_file, 'r') as f:
-        data = json.loads(f.read())
-        df = pd.concat([df, pd.DataFrame([data])])
+    # Append log files to the dataframe
+    for log_file in log_files:
+        with open(log_file, 'r') as f:
+            data = json.loads(f.read())
+            df = pd.concat([df, pd.DataFrame([data])])
 
-# Sort by processor count, print for reference
-df.sort_values(by='nproc', inplace=True)
-print(df)
+    # Sort by processor count, print for reference
+    df.sort_values(by='nproc', inplace=True)
 
-# Calculate and plot speedup factor
-serial_time = df.iloc[0]['execution_time']
-plt.plot(df['nproc'], serial_time/df['execution_time'], 'o', label='Actual')
+    # Calculate speedup factor
+    serial_wall_time = df.iloc[0]['execution_time']
+    df["speedup"] = df["execution_time"].apply(amdahl_speedup,
+                                               args=(serial_wall_time,))
 
-# Calculate and plot theoretical speedup factor
-parallel_proportion = df.iloc[0]['parallel_proportion']
-serial_proportion = 1 - parallel_proportion
-processors_range = range(1, df['nproc'].max())
-speedup = 1.0 / (serial_proportion + (parallel_proportion/processors_range))
-plt.plot(processors_range, speedup, ':', label='Theoretical')
+    # Print out the data frame as a table
+    print(df.to_string(index=False))
 
-# Make graph more legible
-plt.xlabel('Number of Processes')
-plt.ylabel('Speedup Factor')
-plt.legend()
-parallel_percent = int(100 * df.iloc[0]['parallel_proportion'])
+    plt.plot(df['nproc'], df["speedup"], 'o', label='Actual')
 
-title = "Amdahl's Law Example, {}% parallel".format(parallel_percent)
-plt.title(title)
+    # Calculate and plot theoretical speedup factor
+    parallel_proportion = df.iloc[0]['parallel_proportion']
+    serial_proportion = 1 - parallel_proportion
+    processors_range = range(1, df['nproc'].max())
+    speedup = 1.0 / (serial_proportion + (parallel_proportion/processors_range))
+    plt.plot(processors_range, speedup, ':', label='Theoretical')
 
-filename = 'amdahl-{}-pct-parallel.png'.format(parallel_percent)
-plt.savefig(filename, dpi=400, bbox_inches='tight')
+    # Make graph more legible
+    plt.xlabel('Number of Processes')
+    plt.ylabel('Speedup Factor')
+
+    parallel_percent = int(100 * df.iloc[0]['parallel_proportion'])
+
+    title = "Amdahl's Law Example, {}% parallel".format(parallel_percent)
+    plt.title(title)
+    plt.legend(loc="best")
+
+    plt.savefig(img_file, dpi=400, bbox_inches='tight')
+
+
+if __name__ == "__main__":
+    # Check whether filenames were supplied
+    usage = "plot_amdahl.py {input_json_files} output_png_file"
+
+    if len(sys.argv) == 0 or (".png" not in sys.argv[-1]):
+        print(usage)
+        sys.exit(1)
+
+    # Get list of log file names
+    log_files = sys.argv[1:-1]
+
+    # Set plot image file name
+    img_file = sys.argv[-1]
+
+    analyze_scaling_study(log_files, img_file)

--- a/code/plot_amdahl.py
+++ b/code/plot_amdahl.py
@@ -3,21 +3,29 @@ Plotting script for HPC Workflows scaling study
 """
 
 import pandas as pd
-import glob
 import json
 import matplotlib
 import matplotlib.pyplot as plt
-matplotlib.use("AGG")
+import sys
+matplotlib.use("AGG")  # plot to disk, rather than to a window
 
-# Get list of log files, read first one into dataframe
-log_files = glob.glob('amdahl_*.json')
-with open(log_files[0], 'r') as f:
-    df = pd.DataFrame([json.loads(f.read())])
+usage = "plot_amdahl.py list_of_inputs.json"
 
-# Append rest of log files into same dataframe
-for log_file in log_files[1:]:
+# Check whether filenames were supplied
+if len(sys.argv) == 0:
+    print(usage)
+    sys.exit(1)
+
+# Get list of log files
+log_files = sys.argv[1:]
+
+df = None  # Initialize an empty DataFrame
+
+# Append log files to the dataframe
+for log_file in log_files:
     with open(log_file, 'r') as f:
-        df = pd.concat([df, pd.DataFrame([json.loads(f.read())])])
+        data = json.loads(f.read())
+        df = pd.concat([df, pd.DataFrame([data])])
 
 # Sort by processor count, print for reference
 df.sort_values(by='nproc', inplace=True)
@@ -29,8 +37,9 @@ plt.plot(df['nproc'], serial_time/df['execution_time'], 'o', label='Actual')
 
 # Calculate and plot theoretical speedup factor
 parallel_proportion = df.iloc[0]['parallel_proportion']
+serial_proportion = 1 - parallel_proportion
 processors_range = range(1, df['nproc'].max())
-speedup = 1.0/((1-parallel_proportion)+parallel_proportion/processors_range)
+speedup = 1.0 / (serial_proportion + (parallel_proportion/processors_range))
 plt.plot(processors_range, speedup, ':', label='Theoretical')
 
 # Make graph more legible
@@ -42,5 +51,5 @@ parallel_percent = int(100 * df.iloc[0]['parallel_proportion'])
 title = "Amdahl's Law Example, {}% parallel".format(parallel_percent)
 plt.title(title)
 
-filename = 'amdahl-{}-percent.png'.format(parallel_percent)
+filename = 'amdahl-{}-pct-parallel.png'.format(parallel_percent)
 plt.savefig(filename, dpi=400, bbox_inches='tight')

--- a/code/plot_amdahl.py
+++ b/code/plot_amdahl.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import sys
 
-from math import ceil
 from matplotlib.lines import Line2D
 
 
@@ -18,6 +17,7 @@ def actual_speedup(parallel_wall_time, serial_wall_time):
 def amdahl_speedup(serial_proportion, parallel_proportion, num_cores):
     normalized_run_time = serial_proportion + (parallel_proportion / num_cores)
     return 1.0 / normalized_run_time
+
 
 def analyze_scaling_study(log_files, img_file):
     # Initialize empty variable to hold data(frame)


### PR DESCRIPTION
For #13. May still need some work on this, but here's a start for the Snakefile and Python code to convert the run*.log files into a speedup graph like the one shown below. Other items of note:

- Since we're not doing real work in the MPI ranks, we can expand the horizontal axis out considerably beyond 8 processors. This gets us closer to the speedup limit, and de-emphasizes the bits of experimental error in the timing results.
- We may need to explicitly specify the number of processes used in `mpirun`, especially in an HPC environment, as `mpirun` may query the scheduler to know how many processes it "should" run.
- My time values aren't particularly close to the theoretical values. Not sure if the Conde-based `mpirun` is deficient or if I'm missing something else. Some runs have been better than others, but for a synthetic example, I'd have expected my values to be practically perfect on every run. -- *Followup: Trevor's results were basically perfect, so it's possibly a local problem. Will check later with current Amdahl code to verify.*

![amdahl-080-percent](https://user-images.githubusercontent.com/1451881/183946108-e76dea47-6619-45a9-ba61-dc7a04897745.png)
